### PR TITLE
Supports registration for DB connection types

### DIFF
--- a/services/idp/api/serverless.js
+++ b/services/idp/api/serverless.js
@@ -2,6 +2,7 @@ import middie from '@fastify/middie'
 import Fastify from 'fastify'
 import { configureOidc } from '../oidc/index.js'
 import { MANAGEMENT } from '../resource-servers/management.js'
+import InteractonsAPI from './oidc/support/interaction.js'
 const config = {}
 const parsedHost = new URL(config?.issuer || process.env.ISSUER)
 const { hostname, protocol, port, pathname } = parsedHost
@@ -43,7 +44,8 @@ app.register(appService, {
   AccountErrors,
   isVercel: true,
   localKeySet,
-  MANAGEMENT_API: MANAGEMENT
+  MANAGEMENT_API: MANAGEMENT,
+  InteractonsAPI
 })
 
 export const handler = async (req, res) => {

--- a/services/idp/ejs-templates/interaction.ejs
+++ b/services/idp/ejs-templates/interaction.ejs
@@ -60,4 +60,7 @@
 <% } %>
 <form autocomplete="off" action="/interaction/<%= uid %>/confirm" method="post">
   <button autofocus type="submit" class="login login-submit" <% if (vercel) { %> onclick="vaTrack()" <% } %>>Continue</button>
+  <div class="login-help">
+    <a href="/interaction/<%= uid %>/abort">[ Cancel ]</a>
+  </div>
 </form>

--- a/services/idp/ejs-templates/layout.ejs
+++ b/services/idp/ejs-templates/layout.ejs
@@ -31,7 +31,6 @@
     </h1>
     <%- body %>
     <div class="login-help">
-      <a href="/interaction/<%= uid %>/abort">[ Cancel ]</a>
       <% if (client.tosUri) { %>
       <a href="<%= client.tosUri %>">[ Terms of Service ]</a>
       <% } %>

--- a/services/idp/ejs-templates/register.ejs
+++ b/services/idp/ejs-templates/register.ejs
@@ -20,7 +20,7 @@
 
 
 
-<form id="authnform" autocomplete="off" action="/interaction/<%= uid %>/login" method="post">
+<form id="authnform" autocomplete="off" action="/interaction/<%= uid %>/register" method="post">
   <input required type="text" name="login" placeholder="Enter any login" <% if (!params.login_hint) {
         %>autofocus="on" <% } else { %> value="<%= params.login_hint %>" <% } %>>
   <input required type="password" name="password" placeholder="and password" <% if (params.login_hint) {
@@ -31,12 +31,10 @@
   <button type="submit" class="login login-submit" <% if (vercel) { %> onclick="vaTrack()" <% } %>>Continue</button>
   <div class="login-help">
     <a href="/interaction/<%= uid %>/abort">[ Cancel ]</a>
-    <% if (supportsRegister) { %>
     <hr />
     <div>
-      Don't have an account? <a href="/interaction/<%= uid %>/register">Sign up</a>
+      Already have an account? <a href="/interaction/<%= uid %>">Sign in</a>
     </div>
-    <% } %>
   </div>
 </form>
 

--- a/services/idp/oidc/events.js
+++ b/services/idp/oidc/events.js
@@ -9,70 +9,77 @@ export default subscribe
 // or for groups of events DEBUG=oidc:event:interaction.*,oidc:event:authorization.*
 
 function subscribe(provider) {
-	const eventHandlers = [
-		['access_token.destroyed', onAccessTokenDestroyed],
-		['access_token.saved', onAccessTokenSaved],
-		['access_token.issued', onAccessTokenIssued],
-		['authorization_code.consumed', onAuthorizationCodeConsumed],
-		['authorization_code.destroyed', onAuthorizationCodeDestroyed],
-		['authorization_code.saved', onAuthorizationCodeSaved],
-		['authorization.accepted', onAuthorizationAccepted],
-		['authorization.error', onAuthorizationError],
-		['authorization.success', onAuthorizationSuccess],
-		['backchannel.error', onBackchannelError],
-		['backchannel.success', onBackchannelSuccess],
-		['jwks.error', onJwksError],
-		['client_credentials.destroyed', onClientCredentialsDestroyed],
-		['client_credentials.saved', onClientCredentialsSaved],
-		['client_credentials.issued', onClientCredentialsIssued],
-		['device_code.consumed', onDeviceCodeConsumed],
-		['device_code.destroyed', onDeviceCodeDestroyed],
-		['device_code.saved', onDeviceCodeSaved],
-		['discovery.error', onDiscoveryError],
-		['end_session.error', onEndSessionError],
-		['end_session.success', onEndSessionSuccess],
-		['grant.error', onGrantError],
-		['grant.revoked', onGrantRevoked],
-		['grant.success', onGrantSuccess],
-		['initial_access_token.destroyed', onInitialAccessTokenDestroyed],
-		['initial_access_token.saved', onInitialAccessTokenSaved],
-		['interaction.destroyed', onInteractionDestroyed],
-		['interaction.ended', onInteractionEnded],
-		['interaction.saved', onInteractionSaved],
-		['interaction.started', onInteractionStarted],
-		['introspection.error', onIntrospectionError],
-		['replay_detection.destroyed', onReplayDetectionDestroyed],
-		['replay_detection.saved', onReplayDetectionSaved],
-		['pushed_authorization_request.error', onPushedAuthorizationRequestError],
-		['pushed_authorization_request.success', onPushedAuthorizationRequestSuccess],
-		['pushed_authorization_request.destroyed', onPushedAuthorizationRequestDestroyed],
-		['pushed_authorization_request.saved', onPushedAuthorizationRequestSaved],
-		['refresh_token.consumed', onRefreshTokenConsumed],
-		['refresh_token.destroyed', onRefreshTokenDestroyed],
-		['refresh_token.saved', onRefreshTokenSaved],
-		['registration_access_token.destroyed', onRegistrationAccessTokenDestroyed],
-		['registration_access_token.saved', onRegistrationAccessTokenSaved],
-		['registration_create.error', onRegistrationCreateError],
-		['registration_create.success', onRegistrationCreateSuccess],
-		['registration_delete.error', onRegistrationDeleteError],
-		['registration_delete.success', onRegistrationDeleteSuccess],
-		['registration_read.error', onRegistrationReadError],
-		['registration_update.error', onRegistrationUpdateError],
-		['registration_update.success', onRegistrationUpdateSuccess],
-		['revocation.error', onRevocationError],
-		['server_error', onServerError],
-		['session.destroyed', onSessionDestroyed],
-		['session.saved', onSessionSaved],
-		['userinfo.error', onUserinfoError]
-	]
+  const eventHandlers = [
+    ['access_token.destroyed', onAccessTokenDestroyed],
+    ['access_token.saved', onAccessTokenSaved],
+    ['access_token.issued', onAccessTokenIssued],
+    ['authorization_code.consumed', onAuthorizationCodeConsumed],
+    ['authorization_code.destroyed', onAuthorizationCodeDestroyed],
+    ['authorization_code.saved', onAuthorizationCodeSaved],
+    ['authorization.accepted', onAuthorizationAccepted],
+    ['authorization.error', onAuthorizationError],
+    ['authorization.success', onAuthorizationSuccess],
+    ['backchannel.error', onBackchannelError],
+    ['backchannel.success', onBackchannelSuccess],
+    ['jwks.error', onJwksError],
+    ['client_credentials.destroyed', onClientCredentialsDestroyed],
+    ['client_credentials.saved', onClientCredentialsSaved],
+    ['client_credentials.issued', onClientCredentialsIssued],
+    ['device_code.consumed', onDeviceCodeConsumed],
+    ['device_code.destroyed', onDeviceCodeDestroyed],
+    ['device_code.saved', onDeviceCodeSaved],
+    ['discovery.error', onDiscoveryError],
+    ['end_session.error', onEndSessionError],
+    ['end_session.success', onEndSessionSuccess],
+    ['grant.error', onGrantError],
+    ['grant.revoked', onGrantRevoked],
+    ['grant.success', onGrantSuccess],
+    ['initial_access_token.destroyed', onInitialAccessTokenDestroyed],
+    ['initial_access_token.saved', onInitialAccessTokenSaved],
+    ['interaction.destroyed', onInteractionDestroyed],
+    ['interaction.ended', onInteractionEnded],
+    ['interaction.saved', onInteractionSaved],
+    ['interaction.started', onInteractionStarted],
+    ['introspection.error', onIntrospectionError],
+    ['replay_detection.destroyed', onReplayDetectionDestroyed],
+    ['replay_detection.saved', onReplayDetectionSaved],
+    ['pushed_authorization_request.error', onPushedAuthorizationRequestError],
+    [
+      'pushed_authorization_request.success',
+      onPushedAuthorizationRequestSuccess
+    ],
+    [
+      'pushed_authorization_request.destroyed',
+      onPushedAuthorizationRequestDestroyed
+    ],
+    ['pushed_authorization_request.saved', onPushedAuthorizationRequestSaved],
+    ['refresh_token.consumed', onRefreshTokenConsumed],
+    ['refresh_token.destroyed', onRefreshTokenDestroyed],
+    ['refresh_token.saved', onRefreshTokenSaved],
+    ['registration_access_token.destroyed', onRegistrationAccessTokenDestroyed],
+    ['registration_access_token.saved', onRegistrationAccessTokenSaved],
+    ['registration_create.error', onRegistrationCreateError],
+    ['registration_create.success', onRegistrationCreateSuccess],
+    ['registration_delete.error', onRegistrationDeleteError],
+    ['registration_delete.success', onRegistrationDeleteSuccess],
+    ['registration_read.error', onRegistrationReadError],
+    ['registration_update.error', onRegistrationUpdateError],
+    ['registration_update.success', onRegistrationUpdateSuccess],
+    ['revocation.error', onRevocationError],
+    ['server_error', onServerError],
+    ['session.destroyed', onSessionDestroyed],
+    ['session.saved', onSessionSaved],
+    ['userinfo.error', onUserinfoError]
+  ]
 
-	eventHandlers.map(([event, handler]) => {
-		const eventLocalDebug = debug(`oidc:event:${event}`)
-		provider.on(event, (...args) => {
-			eventLocalDebug(handler.name, ...args)
-			handler(...args)
-		})
-	})
+  eventHandlers.map(([event, handler]) => {
+    const eventLocalDebug = debug(`oidc:event:${event}`)
+    provider.on(event, (...args) => {
+      const filtered = args.filter((arg) => !arg.req)
+      eventLocalDebug(handler.name, ...filtered)
+      handler(...args)
+    })
+  })
 }
 
 /**

--- a/services/idp/oidc/support/configuration.js
+++ b/services/idp/oidc/support/configuration.js
@@ -37,6 +37,7 @@ export default {
       'HS512'
     ]
   },
+  extraParams: ['connection'],
   // TODO dynamic skip consent loading for Resource Servers based on loadExistingGrant
   extraClientMetadata: {
     properties: [CORS_PROP, F0_TYPE_PROP],
@@ -57,7 +58,6 @@ export default {
     return client[CORS_PROP].includes(origin)
   },
   async renderError(ctx, out, error) {
-    console.log('renderError', error)
     defaults.renderError(ctx, out, error)
   },
   clients: [TESTER],

--- a/services/idp/oidc/support/connection.js
+++ b/services/idp/oidc/support/connection.js
@@ -16,6 +16,10 @@ class Connection {
     const connectionsFound = await prisma.clientConnection.findMany(args)
     return connectionsFound.map((x) => x.connection)
   }
+  static async getAllConnections() {
+    const connectionsFound = await prisma.connection.findMany()
+    return connectionsFound
+  }
 }
 
 export { Connection }

--- a/services/idp/oidc/support/interaction.js
+++ b/services/idp/oidc/support/interaction.js
@@ -1,0 +1,26 @@
+import prisma from '../../db/client.js'
+
+export default {
+  clearInteractionError
+}
+
+async function clearInteractionError(uid) {
+  const interaction = await prisma.oidcModel.findFirst({ where: { id: uid } })
+  if (!interaction) {
+    return
+  }
+  const nextPayload = interaction.payload
+  if (!nextPayload.lastSubmission) {
+    return
+  }
+  const lastSubmission = { ...nextPayload.lastSubmission }
+  lastSubmission.user_error_desc = undefined
+  lastSubmission.user_error = undefined
+  lastSubmission.lastAction = undefined
+  nextPayload.lastSubmission = lastSubmission
+
+  await prisma.oidcModel.update({
+    where: { id: uid },
+    data: { payload: nextPayload }
+  })
+}

--- a/services/idp/prisma/migrations/20240131103155_unique_connection_names/migration.sql
+++ b/services/idp/prisma/migrations/20240131103155_unique_connection_names/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[name]` on the table `connection` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "connection_name_key" ON "connection"("name");

--- a/services/idp/prisma/schema.prisma
+++ b/services/idp/prisma/schema.prisma
@@ -152,7 +152,7 @@ model ResourceServer {
 
 model Connection {
   id               String             @id @default(dbgenerated("gen_random_uuid()"))
-  name             String
+  name             String             @unique
   updatedAt        DateTime           @default(now()) @updatedAt
   type             CONNECTION_TYPE    @default(DB)
   ClientConnection ClientConnection[]

--- a/services/idp/routes/interaction/index.js
+++ b/services/idp/routes/interaction/index.js
@@ -23,6 +23,8 @@ export default async function interactionsRouter(fastify, opts) {
   const Account = opts.Account
   const Connection = opts.Connection
   const AccountErrors = opts.AccountErrors
+  const InteractonsAPI = opts.InteractonsAPI
+
   function errorHandler(error, request, reply) {
     if (error instanceof FST_ERR_BAD_STATUS_CODE) {
       this.log.error(error)
@@ -39,10 +41,12 @@ export default async function interactionsRouter(fastify, opts) {
   fastify.register(FormBody)
   fastify.register(NoCache)
 
-  fastify.get('/:uid', getInteraction)
-  fastify.post('/:uid/login', checkLogin)
-  fastify.post('/:uid/confirm', interactionConfirm)
-  fastify.get('/:uid/abort', interactionAbort)
+  fastify.get('/:uid', getInteraction) // render login prompt - login page
+  fastify.get('/:uid/register', getInteraction) // render login prompt - register page
+  fastify.post('/:uid/login', checkLogin) // submit login prompt with authentication
+  fastify.post('/:uid/register', registerUser) // submit login prompt with registration
+  fastify.post('/:uid/confirm', interactionConfirm) // submit consent prompt
+  fastify.get('/:uid/abort', interactionAbort) // abort the interaction
 
   async function getInteraction(request, reply) {
     const provider = this.oidc
@@ -53,9 +57,29 @@ export default async function interactionsRouter(fastify, opts) {
       session,
       lastSubmission = {}
     } = await provider.interactionDetails(request, reply)
+    const isRegister =
+      request.url.includes('register') ||
+      lastSubmission.lastAction === 'register'
 
     const client = await provider.Client.find(params.client_id)
     const connections = await Connection.getEnabledConnections(client.clientId)
+    const connectionsSupportingRegister =
+      connections.filter((c) => c.disableSignup).length === 0
+
+    if (isRegister && !connectionsSupportingRegister) {
+      const result = {
+        error: 'access_denied',
+        error_description: 'No connections support registration'
+      }
+      const returnTo = await provider.interactionResult(
+        request,
+        reply,
+        result,
+        NO_MERGE
+      )
+      reply.header('Content-Length', 0)
+      return reply.redirect(303, returnTo)
+    }
 
     const connectionTypes = new Set(connections.map((x) => x.type))
 
@@ -89,20 +113,28 @@ export default async function interactionsRouter(fastify, opts) {
 
     switch (prompt.name) {
       case 'login': {
-        return reply.view('login.ejs', {
+        const viewName = isRegister ? 'register.ejs' : 'login.ejs'
+        const title = isRegister ? 'Register' : 'Sign In'
+        // resetError
+        const error = lastSubmission.user_error_desc
+        if (error) {
+          await InteractonsAPI.clearInteractionError(request.params.uid)
+        }
+        return reply.view(viewName, {
           nonce,
           client,
           uid,
           details: prompt.details,
           params,
-          title: 'Sign-in',
+          title,
+          supportsRegister: connectionsSupportingRegister,
           connectionTypes,
           session: session ? debug(session) : undefined,
           dbg: {
             params: debug(params),
             prompt: debug(prompt)
           },
-          error: lastSubmission.user_error_desc
+          error
         })
       }
       case 'consent': {
@@ -145,7 +177,69 @@ export default async function interactionsRouter(fastify, opts) {
       }
       const iErr = {
         user_error: 'access_denied',
-        user_error_desc: 'Invalid email or password'
+        user_error_desc: 'Invalid email or password',
+        lastAction: 'login'
+      }
+      const returnTo = await provider.interactionResult(
+        request,
+        reply,
+        iErr,
+        NO_MERGE
+      )
+      return reply.redirect(303, returnTo)
+    }
+
+    const result = { login: { accountId: account.accountId } }
+
+    const returnTo = await provider.interactionResult(
+      request,
+      reply,
+      result,
+      NO_MERGE
+    )
+    return reply.redirect(303, returnTo)
+  }
+
+  async function registerUser(request, reply) {
+    const provider = this.oidc
+    const {
+      prompt: { name },
+      params
+    } = await provider.interactionDetails(request, reply)
+
+    assert.equal(name, 'login')
+    const client = await provider.Client.find(params.client_id)
+    const connections = await Connection.getEnabledConnections(client.clientId)
+    const dbConnections = connections.filter((c) => c.type === 'DB')
+    if (dbConnections.length === 0) {
+      const returnTo = await provider.interactionResult(
+        request,
+        reply,
+        {
+          user_error: 'access_denied',
+          user_error_desc: 'No connections support registration'
+        },
+        MERGE
+      )
+      return reply.redirect(303, returnTo)
+    }
+    let account
+    try {
+      account = await Account.register(
+        request.body.login,
+        request.body.password,
+        dbConnections[0].id
+      )
+    } catch (error) {
+      this.log.error(error)
+
+      if (!(error instanceof AccountErrors.AccountExists)) {
+        throw error
+      }
+      const iErr = {
+        user_error: 'access_denied',
+        user_error_desc: 'Account already exists',
+        lastAction: 'register'
       }
       const returnTo = await provider.interactionResult(
         request,

--- a/services/idp/server.js
+++ b/services/idp/server.js
@@ -1,4 +1,3 @@
-import crypto from 'crypto'
 import middie from '@fastify/middie'
 import FastifySwagger from '@fastify/swagger'
 import Scalar from '@scalar/fastify-api-reference'
@@ -6,9 +5,9 @@ import closeWithGrace from 'close-with-grace'
 import { filename } from 'desm'
 import { fastify as Fastify } from 'fastify'
 import './env.js'
-//console.log(crypto.getCurves())
 
 import { configureOidc } from './oidc/index.js'
+import InteractonsAPI from './oidc/support/interaction.js'
 import { MANAGEMENT } from './resource-servers/management.js'
 import { swaggerOpts } from './swagger-opts.js'
 
@@ -65,7 +64,8 @@ async function makeFastify(config, pretty) {
     Account,
     AccountErrors,
     localKeySet,
-    MANAGEMENT_API: MANAGEMENT
+    MANAGEMENT_API: MANAGEMENT,
+    InteractonsAPI
   })
 
   // delay is the number of milliseconds for the graceful close to finish
@@ -95,9 +95,7 @@ async function makeFastify(config, pretty) {
 async function start(port, pretty) {
   const app = await makeFastify(null, pretty)
   await app.register(FastifySwagger, swaggerOpts)
-  await app.register(Scalar, {
-    routePrefix: '/reference'
-  })
+  await app.register(Scalar, { routePrefix: '/reference' })
   await app.ready()
 
   // console.log(

--- a/services/idp/test/authorization-code/interaction-bad-password.test.js
+++ b/services/idp/test/authorization-code/interaction-bad-password.test.js
@@ -43,8 +43,9 @@ describe('interaction router', () => {
       }
     })
     const containsLoginTitle = interactionResponse.body.includes(
-      '<title>Sign-in</title>'
+      '<title>Sign In</title>'
     )
+
     expect(containsLoginTitle).toBe(true)
     expect(statusCode).toEqual(303)
     expect(headers.location).toMatch('/interaction')

--- a/services/idp/test/authorization-code/interaction-good-password.test.js
+++ b/services/idp/test/authorization-code/interaction-good-password.test.js
@@ -54,7 +54,7 @@ describe('interaction router', () => {
       }
     })
     const containsLoginTitle = interactionResponse.body.includes(
-      '<title>Sign-in</title>'
+      '<title>Sign In</title>'
     )
     expect(containsLoginTitle).toBe(true)
     expect(statusCode).toEqual(303)

--- a/services/manage/src/App.js
+++ b/services/manage/src/App.js
@@ -30,7 +30,12 @@ const routes = [
     children: [
       {
         path: 'tester/callback',
-        element: <Tester />
+        element: <Tester />,
+        loader: async ({ request }) => {
+          const searchParams = new URL(request.url).searchParams
+          const connectionName = searchParams.get('connection')
+          return { connectionName }
+        }
       },
       {
         path: '/',

--- a/services/manage/src/components/Connection/Tester.js
+++ b/services/manage/src/components/Connection/Tester.js
@@ -1,6 +1,7 @@
 import { Button, Group, Paper, Stack } from '@mantine/core'
 import { useContext, useState } from 'react'
 import { AuthContext, AuthProvider } from 'react-oauth2-code-pkce'
+import { useLoaderData } from 'react-router-dom'
 import { userInfo } from '../../api'
 const ISSUER = process.env.REACT_APP_ISSUER
 const ORIGIN = window.location.origin
@@ -10,7 +11,6 @@ const authConfig = {
   tokenEndpoint: `${ISSUER}/token`,
   redirectUri: `${ORIGIN}/tester/callback`,
   scope: ['openid', 'profile', 'email', 'address', 'phone'].join(' '),
-
   extraAuthParameters: {
     prompt: 'login'
   },
@@ -22,6 +22,11 @@ const authConfig = {
 }
 
 export function Tester() {
+  const { connectionName } = useLoaderData()
+  // prevents sending a stringified 'null'
+  if (connectionName) {
+    authConfig.extraAuthParameters.connection = connectionName
+  }
   return (
     <AuthProvider authConfig={authConfig}>
       <IsolatedApp />

--- a/services/manage/src/components/Connection/index.js
+++ b/services/manage/src/components/Connection/index.js
@@ -78,7 +78,9 @@ function Header() {
         </Stack>
       </Group>
       <Button
-        onClick={(e) => navigate('/tester/callback')}
+        onClick={(e) =>
+          navigate(`/tester/callback?connection=${connection.name}`)
+        }
         variant="outline"
         rightSection={
           <ThemeIcon variant={'transparent'}>


### PR DESCRIPTION
Closes #76 

TODO:
- [x] support provided `connection` parameter in interactions logic, passed as part of Redirect to authn endpoint that will scope users to only that single connection